### PR TITLE
Unify external app hooks

### DIFF
--- a/apps/logger/external.py
+++ b/apps/logger/external.py
@@ -10,40 +10,25 @@ import wifi
 import gc
 import onboard
 
+needs_wifi = True
+period = 1 * 1000
+needs_icon = True
 
-
-update_rate = 15
-
-i=0
-
-#def get_battery_voltage(adc_obj, ref_obj):
-#	vin = adc_obj.read()
-#	ref_reading = ref_obj.read()
-#	factory_reading = stm.mem16[0x1FFF75AA]
-#	reference_voltage = factory_reading/4095*3
-#	supply_voltage = 4095/ref_reading*reference_voltage 
-#	return 2 * vin / 4095 * supply_voltage
-	
-
-
-
-def periodic_home(icon):
-
-
+i = 0
+def tick(icon):
 	global i
+	i+=1
+
 	icon.show()
 	ugfx.set_default_font("c*")
 	icon.area(0,0,icon.width(),icon.height(),0xFFFF)
 	icon.text(0,0,str(i),0)
-	i+=1
-	
+
 	bv = onboard.get_battery_voltage()
 	uv = onboard.get_unreg_voltage()
 	li = onboard.get_light()
-	
-	logfile = "log.txt"
-	
 
+	logfile = "log.txt"
 
 	if database_get("stats_upload", 0):
 		urlparams = "origin=PBADGE0&data=0bV" + str(bv) + "%5BPBADGE0%5D"
@@ -54,18 +39,16 @@ def periodic_home(icon):
 		except OSError as e:
 			print("Upload failed " + str(e))
 
-		
-		
 	try:
 		if not is_file(logfile):
 			with open(logfile, "w") as f:
 				f.write("vbat, vunreg, light \r\n")
-		
+
 		with open(logfile, "a") as f:
 			f.write(str(bv) + ", " + str(uv) + ", " + str(li) + "\r\n")
 	except OSError as e:
 		print("Logging failed: " + str(e))
 		return "Logging failed"
-		
-		
+
+
 	return "Logged " + str(bv)


### PR DESCRIPTION
There used to be two differrent concepts that were mostly similar but not quite. This unifies them and allows all combinations of frequency/icons/wifi

Changes to apps:
* Rename all callback functions to ```tick()```
* Define ```needs_wifi```, ```period``` and ```needs_icon``` in the module (if needed)