### PR TITLE
Add ability to run script as main.py

### DIFF
--- a/boot.py
+++ b/boot.py
@@ -12,9 +12,18 @@ m = "bootstrap.py"
 if "main.py" in os.listdir():
     m = "main.py"
 elif "apps" in os.listdir():
-	apps = os.listdir("apps")
-	if ("home" in apps) and ("main.py" in os.listdir("apps/home")):
-		m = "apps/home/main.py"
-	elif ("app_library" in apps) and ("main.py" in os.listdir("apps/app_library")):
-		m = "apps/app_library/main.py"
+    apps = os.listdir("apps")
+    if ("home" in apps) and ("main.py" in os.listdir("apps/home")):
+        m = "apps/home/main.py"
+    elif ("app_library" in apps) and ("main.py" in os.listdir("apps/app_library")):
+        m = "apps/app_library/main.py"
+if 'main.json' in os.listdir():
+    try:
+        with open('main.json', 'r') as f:
+            main_dict = json.loads(f.read())
+            m = main_dict['main']
+            if not main_dict.get('perm', False):
+                os.remove('main.json')
+    except:
+        pass
 pyb.main(m)

--- a/examples/run_as_main.py
+++ b/examples/run_as_main.py
@@ -1,0 +1,2 @@
+with open('main.json', 'w') as f:
+    f.write('{"main":"apps/snake/main.py"}')


### PR DESCRIPTION
Due to limited memory, large apps can crash if they are imported by the main process. This commit offers a mechanism to temporarily (or permanently if desired) redefine the main.py that should be run so that it has access to all available memory. An example way of doing this is given in the example run_as_main.py