### PR TITLE
Allow apps to specify USB HID mode

### DIFF
--- a/apps/home/file_loader.py
+++ b/apps/home/file_loader.py
@@ -154,8 +154,9 @@ if app_to_load:
 	buttons.enable_menu_reset()
 	import run_app
 	rbr = app_to_load.get_attribute("reboot-before-run")
+	usb = app_to_load.get_attribute("usb-mode")
 	if type(rbr) == str and rbr.lower() == "false": 
 		run_app.run_app(app_to_load.main_path[:-3])
-	run_app.reset_and_run(app_to_load.main_path[:-3])
+	run_app.reset_and_run(app_to_load.main_path[:-3], usb_mode=usb)
 	
 	

--- a/apps/home/quick_launch.py
+++ b/apps/home/quick_launch.py
@@ -135,9 +135,10 @@ if torun:
 		run_app.run_app("apps/home/file_loader")
 	else:	
 		rbr = torun.get_attribute("reboot-before-run")
+		usb = torun.get_attribute("usb-mode")
 		if type(rbr) == str and rbr.lower() == "false":
 			run_app.run_app(torun.main_path[:-3])
-		run_app.reset_and_run(torun.main_path[:-3])
+		run_app.reset_and_run(torun.main_path[:-3], usb_mode=usb)
 	
 	#ugfx.area(0,0,ugfx.width(),ugfx.height(),0)
 

--- a/boot.py
+++ b/boot.py
@@ -7,6 +7,7 @@
 import pyb
 import os
 import micropython
+import json
 
 micropython.alloc_emergency_exception_buf(100)
 
@@ -19,4 +20,14 @@ elif "apps" in os.listdir():
 		m = "apps/home/main.py"
 	elif ("app_library" in apps) and ("main.py" in os.listdir("apps/app_library")):
 		m = "apps/app_library/main.py"
+
+# must set USB mode before calling pyb.main()
+try:
+    with open('main.json', 'r') as f:
+        main_dict = json.loads(f.read())
+        u = main_dict.get('usb_mode')
+        if u:
+            pyb.usb_mode(u)
+except OSError:
+    pass
 pyb.main(m)

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -21,28 +21,6 @@ def get_app_foldername(path):
 	else:
 		return s[-2]
 
-def get_app_attribute(path, attribute):
-	if not is_file(path):
-		return ""
-	rv = ""
-	attribute = attribute.lower()
-	try:
-		with open(path) as f:
-			while True:  ## ToDo: set the max lines to loop over to be 20 or so
-				l = f.readline()
-				if l.startswith("### "):
-					kv = l[4:].split(":",1)
-					if len(kv) >= 2:
-						if (kv[0].strip().lower() == attribute):
-							rv = kv[1].strip()
-							break;
-				else:
-					break
-
-	except OSError as e:
-		return ""
-	return rv
-
 def is_dir(path):
     """Checks whether a path exists and is a director"""
     try:

--- a/lib/run_app.py
+++ b/lib/run_app.py
@@ -3,10 +3,11 @@ def reset_and_run(path, usb_mode=None):
 	import pyb
 #	if stm.mem8[0x40002850] == 0:   # this battery backed RAM section is set to 0 when the name screen runs
 	with open('main.json', 'w') as f:
-		f.write('{"main":"' + path + '"')
+		import json
+		d = {'main': path}
 		if usb_mode:
-			f.write(',"usb_mode":"' + usb_mode + '"')
-		f.write('}')
+			d['usb_mode'] = usb_mode
+		f.write(json.dumps(d))
 #		stm.mem8[0x40002850] = 2    #set this address to != 0 so this if statement doesnt run next time
 	pyb.hard_reset()
 

--- a/lib/run_app.py
+++ b/lib/run_app.py
@@ -1,9 +1,12 @@
 
-def reset_and_run(path):
+def reset_and_run(path, usb_mode=None):
 	import pyb
 #	if stm.mem8[0x40002850] == 0:   # this battery backed RAM section is set to 0 when the name screen runs
 	with open('main.json', 'w') as f:
-		f.write('{"main":"' + path + '"}')
+		f.write('{"main":"' + path + '"')
+		if usb_mode:
+			f.write(',"usb_mode":"' + usb_mode + '"')
+		f.write('}')
 #		stm.mem8[0x40002850] = 2    #set this address to != 0 so this if statement doesnt run next time
 	pyb.hard_reset()
 


### PR DESCRIPTION
This PR allows badge apps to specify the USB mode they want to run in via app attributes. An example app which can do this is my fork of @bcaller's usbmouse here: https://github.com/philandstuff/emfbadge-usbmouse/blob/app-attributes/main.py

The three commits in this PR are pretty independent, and all documented in their respective commit messages:
- @2ce141c removes what seems to be some dead code which confused me when I was doing this work
- @7e9166c allows setting a custom USB mode; in HID mode, the board will act as a USB mouse
- @74aca30 extends this to allow custom HID devices other than mice.

I'm not super happy with the custom HID devices bit but it does work.
