### PR TITLE
Next release fixes

### DIFF
--- a/apps/app_library/main.py
+++ b/apps/app_library/main.py
@@ -42,7 +42,7 @@ def download(url, target, expected_hash):
 def download_list(items, message_dialog):
     for i, item in enumerate(items):
         message_dialog.text = "Downloading %s (%d/%d)" % (item["title"], i + 1, len(items))
-        http_client.get(item["url"]).raise_for_status().download_to(item["target"])
+        download(item["url"], item["target"], item["expected_hash"])
 
 def download_app(app, message_dialog):
     files_to_update = []

--- a/apps/app_library/main.py
+++ b/apps/app_library/main.py
@@ -117,6 +117,7 @@ def store():
     global apps_by_category
 
     while True:
+        empty_local_app_cache()
         clear()
         connect()
 
@@ -135,6 +136,7 @@ def store_category(category):
         app = dialogs.prompt_option(get_public_apps(category), text="Please select an app", select_text="Details / Install", none_text="Back")
         if app:
             store_details(category, app)
+            empty_local_app_cache()
         else:
             return
 

--- a/apps/app_library/main.py
+++ b/apps/app_library/main.py
@@ -4,8 +4,6 @@
 ### reboot-before-run: True
 ### Appname: App Library
 
-
-import stm
 import pyb
 import ugfx
 import os
@@ -177,6 +175,6 @@ def remove():
 if App("home").loadable:
     main_menu()
 else:
-    for app_name in ["sponsors", "changename", "snake", "rnalexander~changefi", "home"]:
+    for app_name in ["changename", "snake", "alistair~selectwifi", "sponsors", "home"]:
         install(App(app_name))
     pyb.hard_reset()

--- a/apps/app_library/main.py
+++ b/apps/app_library/main.py
@@ -64,9 +64,12 @@ def download_app(app, message_dialog):
     download_list(files_to_update, message_dialog)
 
 def connect():
-    if not wifi.is_connected():
-        with dialogs.WaitingMessage(text=wifi.connection_text(), title="TiLDA App Library") as message:
-            wifi.connect()
+    wifi.connect(
+        wait=True,
+        show_wait_message=True,
+        prompt_on_fail=True,
+        dialog_title='TiLDA App Library'
+    )
 
 ### VIEWS ###
 

--- a/apps/app_library/main.py
+++ b/apps/app_library/main.py
@@ -32,7 +32,10 @@ def download(url, target, expected_hash):
         if count > 5:
             os.remove(TEMP_FILE)
             raise OSError("Aborting download of %s after 5 unsuccessful attempts" % url)
-        http_client.get(url).raise_for_status().download_to(TEMP_FILE)
+        try:
+            http_client.get(url).raise_for_status().download_to(TEMP_FILE)
+        except OSError:
+            pass
 
     os.rename(TEMP_FILE, target)
 

--- a/apps/home/file_loader.py
+++ b/apps/home/file_loader.py
@@ -154,8 +154,8 @@ if app_to_load:
 	buttons.enable_menu_reset()
 	import run_app
 	rbr = app_to_load.get_attribute("reboot-before-run")
-	if type(rbr) == str and rbr.lower() == "true": 
-		run_app.reset_and_run(app_to_load.main_path[:-3])
-	run_app.run_app(app_to_load.main_path[:-3])
+	if type(rbr) == str and rbr.lower() == "false": 
+		run_app.run_app(app_to_load.main_path[:-3])
+	run_app.reset_and_run(app_to_load.main_path[:-3])
 	
 	

--- a/apps/home/home.py
+++ b/apps/home/home.py
@@ -275,6 +275,7 @@ def home_main():
 				wifi_reconnect_timeout = 30 #try again in 30sec
 
 			wifi_is_connected = wifi.nic().is_connected()
+			time_set = False
 
 			#if not connected, see if we should try again
 			if not wifi_is_connected:
@@ -289,7 +290,7 @@ def home_main():
 				# If we've just connected, set NTP time
 				if wifi_did_connect == 0:
 					wifi_did_connect = 1
-					ntp.set_NTP_time()
+					time_set = ntp.set_NTP_time()
 
 			ledg.on()
 
@@ -300,7 +301,8 @@ def home_main():
 			else:
 				last_rssi = rssi
 
-			draw_time(sty_tb.background(), pyb.RTC().datetime(), win_clock)
+			if time_set:
+				draw_time(sty_tb.background(), pyb.RTC().datetime(), win_clock)
 
 			draw_wifi(sty_tb.background(),rssi, wifi_is_connected,wifi_timeout>0,win_wifi)
 

--- a/apps/home/home.py
+++ b/apps/home/home.py
@@ -6,19 +6,15 @@
 ### Built-in: hide
 
 
-import os
 import ugfx
 import pyb
 from database import *
 from filesystem import *
 import buttons
 import gc
-import stm
 import apps.home.draw_name
 import wifi
-import gc
 from imu import IMU
-import pyb
 import onboard
 import dialogs
 from app import *
@@ -145,7 +141,7 @@ orientation = ugfx.orientation()
 
 with Database() as db:
 	if not db.get("home_firstrun"):
-		stats_upload = dialogs.prompt_boolean("""Press menu to see all the available apps and download more.""", title="Welcome to the EMF camp badge!", true_text="OK", false_text = None, width = 320, height = 240)
+		stats_upload = dialogs.prompt_boolean("""Press menu to see all the available apps and download more.""", title="Welcome to the EMF camp badge!", true_text="A: OK", false_text = None, width = 320, height = 240)
 		db.set("home_firstrun", True)
 		db.set("stats_upload", stats_upload)
 

--- a/apps/home/home.py
+++ b/apps/home/home.py
@@ -220,10 +220,9 @@ def home_main():
 	wifi_reconnect_timeout = 0
 	wifi_did_connect = 0
 	try:
-		wifi.connect(wait = False)
+		wifi.connect(wait = False, prompt_on_fail = False)
 	except OSError:
-		print("Creating default wifi settings file")
-		wifi.create_default_config()
+		print("Connect failed")
 
 	while True:
 		pyb.wfi()

--- a/apps/home/quick_launch.py
+++ b/apps/home/quick_launch.py
@@ -135,9 +135,9 @@ if torun:
 		run_app.run_app("apps/home/file_loader")
 	else:	
 		rbr = torun.get_attribute("reboot-before-run")
-		if type(rbr) == str and rbr.lower() == "true":
-			run_app.reset_and_run(torun.main_path[:-3])
-		run_app.run_app(torun.main_path[:-3])
+		if type(rbr) == str and rbr.lower() == "false":
+			run_app.run_app(torun.main_path[:-3])
+		run_app.reset_and_run(torun.main_path[:-3])
 	
 	#ugfx.area(0,0,ugfx.width(),ugfx.height(),0)
 

--- a/apps/home/quick_launch.py
+++ b/apps/home/quick_launch.py
@@ -4,10 +4,7 @@ import buttons
 import dialogs
 from database import *
 from filesystem import *
-import sys
-import uio
 import gc
-import onboard
 from app import *
 
 ugfx.init()
@@ -25,7 +22,7 @@ def quick_launch_screen():
 	win_quick = ugfx.Container(0,33,wi,hi-33-33)
 	win_help = ugfx.Container(0,hi-30,wi,30)
 
-	DEFAULT_APPS = ["app_library", "sponsors", "changename"]
+	DEFAULT_APPS = ["app_library", "changename", "alistair~selectwifi", "snake"]
 	with Database() as db:
 		pinned = [App(a) for a in db.get("pinned_apps", DEFAULT_APPS)]
 		pinned = [app for app in pinned if app.loadable] # Filter out deleted apps

--- a/apps/home/quick_launch.py
+++ b/apps/home/quick_launch.py
@@ -38,7 +38,7 @@ def quick_launch_screen():
 	for i in range(0, 8):
 		x = i % 2
 		y = i // 2
-		button_title = "View all" if i == 7 else ""
+		button_title = "Installed Apps" if i == 7 else ""
 		if i < len(pinned):
 			button_title = pinned[i].title
 		pinned_buttons.append(ugfx.Button(35 + 155 * x, 5 + 40 * y, 120, 35, button_title, parent=win_quick))
@@ -68,7 +68,7 @@ def quick_launch_screen():
 	if not database_get("quicklaunch_firstrun"):
 		dialogs.notice("""This screen displays the most commonly used apps.
 Apps pinned here can also interact with the name screen.
-To view all apps, pin and un-pin, select 'View All'
+To view all apps, pin and un-pin, select 'Installed Apps'
 		""", title="TiLDA - Quick Launch", close_text="Close")
 		database_set("quicklaunch_firstrun", True)
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,293 +1,137 @@
 # TiLDA Badge Bootstrap script
 # Automatically downloads the app library to the badge via wifi
-import network, pyb, usocket, machine, os, json, ugfx, ujson, hashlib, binascii, uio, sys
-
-### START lib/http_client.py ###
-SUPPORT_TIMEOUT = hasattr(usocket.socket, 'settimeout')
-CONTENT_TYPE_JSON = 'application/json'
-DELAY_BETWEEN_READS = 50
-BUFFER_SIZE = 128
-
-class Response(object):
-	def __init__(self):
-		self.encoding = 'utf-8'
-		self.headers = {}
-		self.status = None
-		self.socket = None
-		self._content = None
-
-	# Hands the responsibility for a socket over to this reponse. This needs to happen
-	# before any content can be inspected
-	def add_socket(self, socket, content_so_far):
-		self.content_so_far = content_so_far
-		self.socket = socket
-
-	@property
-	def content(self):
-		if not self._content:
-			if not self.socket:
-				raise OSError("Invalid response socket state. Has the content been downloaded instead?")
-			try:
-				if "Content-Length" not in self.headers:
-					raise Exception("No Content-Length")
-				content_length = int(self.headers["Content-Length"])
-				self._content = self.content_so_far
-				del self.content_so_far
-				while len(self._content) < content_length:
-					pyb.delay(DELAY_BETWEEN_READS)
-					buf = self.socket.recv(BUFFER_SIZE)
-					self._content += buf
-
-			finally:
-				self.close()
-		return self._content;
-
-	@property
-	def text(self):
-		return str(self.content, self.encoding) if self.content else ''
-
-	# If you don't use the content of a Response at all you need to manually close it
-	def close(self):
-		if self.socket is not None:
-			self.socket.close()
-			self.socket = None
-
-	def json(self):
-		return ujson.loads(self.text)
-
-	# Writes content into a file. This function will write while receiving, which avoids
-	# having to load all content into memory
-	def download_to(self, target):
-		if not self.socket:
-			raise OSError("Invalid response socket state. Has the content already been consumed?")
-		try:
-			if "Content-Length" not in self.headers:
-				raise Exception("No Content-Length")
-			remaining = int(self.headers["Content-Length"])
-
-			with open(target, 'wb') as f:
-				f.write(self.content_so_far)
-				remaining -= len(self.content_so_far)
-				del self.content_so_far
-				while remaining > 0:
-					pyb.delay(DELAY_BETWEEN_READS)
-					buf = self.socket.recv(BUFFER_SIZE)
-					f.write(buf)
-					remaining -= len(buf)
-				f.flush()
-			os.sync()
-
-		finally:
-			self.close()
-
-	def raise_for_status(self):
-		if 400 <= self.status < 500:
-			raise OSError('Client error: %s' % self.status)
-		if 500 <= self.status < 600:
-			raise OSError('Server error: %s' % self.status)
-		return self
-
-	# In case you want to use "with"
-	def __enter__(self):
-		return self
-
-	def __exit__(self, exc_type, exc_value, traceback):
-		self.close()
-
-def open_http_socket(method, url, json=None, timeout=None, headers=None, urlencoded = None):
-	urlparts = url.split('/', 3)
-	proto = urlparts[0]
-	host = urlparts[2]
-	urlpath = '' if len(urlparts) < 4 else urlparts[3]
-
-	if proto == 'http:':
-		port = 80
-	elif proto == 'https:':
-		port = 443
-	else:
-		raise OSError('Unsupported protocol: %s' % proto[:-1])
-
-	if ':' in host:
-		host, port = host.split(':')
-		port = int(port)
-
-	if json is not None:
-		content = ujson.dumps(json)
-		content_type = CONTENT_TYPE_JSON
-	elif urlencoded is not None:
-		content = urlencoded
-		content_type = "application/x-www-form-urlencoded"
-	else:
-		content = None
-
-	# ToDo: Detect IP addresses and skip the lookup
-	ai = usocket.getaddrinfo(host, port)
-	addr = ai[0][4]
-
-	sock = None
-	if proto == 'https:':
-		sock = usocket.socket(usocket.AF_INET, usocket.SOCK_STREAM, usocket.SEC_SOCKET)
-	else:
-		sock = usocket.socket()
-
-	sock.connect(addr)
-	if proto == 'https:':
-		sock.settimeout(0) # Actually make timeouts working properly with ssl
-
-	sock.send('%s /%s HTTP/1.0\r\nHost: %s\r\n' % (method, urlpath, host))
-
-	if headers is not None:
-		for header in headers.items():
-			sock.send('%s: %s\r\n' % header)
-
-	if content is not None:
-		sock.send('content-length: %s\r\n' % len(content))
-		sock.send('content-type: %s\r\n' % content_type)
-		sock.send('\r\n')
-		sock.send(content)
-	else:
-		sock.send('\r\n')
-
-	return sock
-
-# Adapted from upip
-def request(method, url, json=None, timeout=None, headers=None, urlencoded=None):
-	sock = open_http_socket(method, url, json, timeout, headers, urlencoded)
-	try:
-		response = Response()
-		state = 1
-		hbuf = b""
-		remaining = None
-		while True:
-			pyb.delay(DELAY_BETWEEN_READS)
-			buf = sock.recv(BUFFER_SIZE)
-			if state == 1: # Status
-				nl = buf.find(b"\n")
-				if nl > -1:
-					hbuf += buf[:nl - 1]
-					response.status = int(hbuf.split(b' ')[1])
-					state = 2
-					hbuf = b"";
-					buf = buf[nl + 1:]
-				else:
-					hbuf += buf
-
-			if state == 2: # Headers
-				hbuf += buf
-				nl = hbuf.find(b"\n")
-				while nl > -1:
-					if nl < 2:
-						buf = hbuf[2:]
-						hbuf = None
-						state = 3
-						break
-
-					header = hbuf[:nl - 1].decode("utf8").split(':', 3)
-					response.headers[header[0].strip()] = header[1].strip()
-					hbuf = hbuf[nl + 1:]
-					nl = hbuf.find(b"\n")
-
-			if state == 3: # Content
-				response.add_socket(sock, buf)
-				sock = None # It's not our responsibility to close the socket anymore
-				return response
-	finally:
-		if sock: sock.close()
-	#	gc.collect()
-
-def get(url, **kwargs):
-	return request('GET', url, **kwargs)
-
-
-### END lib/http_client.py ###
+import pyb
+import machine
+import os
+import json
+import ugfx
+import hashlib
+import binascii
+import uio
+import sys
+import buttons
+import dialogs
+import wifi
+from http_client import get
 
 def calculate_hash(filename):
-	try:
-		with open(filename, "rb") as file:
-			sha256 = hashlib.sha256()
-			buf = file.read(128)
-			while len(buf) > 0:
-				sha256.update(buf)
-				buf = file.read(128)
-			return str(binascii.hexlify(sha256.digest()), "utf8")
-	except:
-		return "ERR"
+    try:
+        with open(filename, "rb") as file:
+            sha256 = hashlib.sha256()
+            buf = file.read(128)
+            while len(buf) > 0:
+                sha256.update(buf)
+                buf = file.read(128)
+        return str(binascii.hexlify(sha256.digest()), "utf8")
+    except:
+        return "ERR"
 
 def download(url, target, expected_hash):
-	while True:
-		get(url).raise_for_status().download_to(target)
-		if calculate_hash(target) == expected_hash:
-			break
+    while True:
+        get(url).raise_for_status().download_to(target)
+        if calculate_hash(target) == expected_hash:
+            break
+
+def choose_wifi():
+    with dialogs.WaitingMessage(text="Scanning for networks...", title="TiLDA Setup"):
+        visible_aps = wifi.nic().list_aps()
+        visible_aps.sort(key=lambda x:x['rssi'], reverse=True)
+        visible_aps = [ ap['ssid'] for ap in visible_aps ]
+
+    ssid = dialogs.prompt_option(
+        visible_aps,
+        text="Choose wifi network", 
+        title="TiLDA Setup"
+    )
+    key = dialogs.prompt_text("Enter wifi key (blank if none)", width = 310, height = 220)
+    if ssid:
+        with open("wifi.json", "wt") as file:
+            if key:
+                conn_details = {"ssid": ssid, "pw": key}
+            else:
+                conn_details = {"ssid": ssid}
+
+            file.write(json.dumps(conn_details))
+        os.sync()
+        pyb.hard_reset()
 
 ugfx.init()
-ugfx.clear(ugfx.WHITE)
-ugfx.text(5, 5, "Downloading TiLDA software", ugfx.BLACK)
-label = ugfx.Label(5, 30, ugfx.width() - 10, ugfx.height() - 60, "Please wait")
-ugfx.Label(5, ugfx.height() - 30, ugfx.width() - 10, 30, "If nothing happens for 2 minutes please press the reset button on the back")
+buttons.init()
+nic = wifi.nic()
 
 w = {}
 try:
-	if "wifi.json" in os.listdir():
-		with open("wifi.json") as f:
-			w = json.loads(f.read())
+    if "wifi.json" in os.listdir():
+        with open("wifi.json") as f:
+	    w = json.loads(f.read())
 except ValueError as e:
-	print(e)
+    print(e)
 
-wifi_info = "\nMore information:\nbadge.emfcamp.org/TiLDA_MK3/wifi"
-if "ssid" not in w:
-	label.text("Couldn't find a valid wifi.json :(" + wifi_info)
-	while True: pyb.wfi()
+timeout = 10
+try:
+    if 'ssid' in w and w['ssid']:
+        with dialogs.WaitingMessage(text="Connecting to '%s'...\n(10s timeout)" % w['ssid'], title="TiLDA Setup") as message:
+            if 'pw' in w:
+                nic.connect(w["ssid"], w["pw"], timeout=timeout)
+            else:
+                nic.connect(w["ssid"], timeout=timeout)
+    else:
+        choose_wifi()
+except OSError:
+    dialogs.notice(
+        text="Failed to connect to '%s'" % w['ssid'],
+        title="TiLDA Setup",
+        close_text="A: Choose another wifi network"
+    )
+    os.remove('wifi.json')
+    pyb.hard_reset()
 
-label.text("Connecting to '%s'.\nIf this is incorrect, please check your wifi.json%s" % (w["ssid"], wifi_info))
-n = network.CC3100()
-if ("pw" in w) and w["pw"]:
-	n.connect(w["ssid"], w["pw"], timeout=10)
-else:
-	n.connect(w["ssid"], timeout=10)
+addendum = "\n\n\n\nIf stalled for 2 minutes please press the reset button on the back"
+with dialogs.WaitingMessage(text="Please wait" + addendum, title="Downloading TiLDA software") as message:
 
-success = False
-failure_counter = 0
-URL = "http://api.badge.emfcamp.org/firmware"
+    success = False
+    failure_counter = 0
+    URL = "http://api.badge.emfcamp.org/firmware"
 
-while not success:
-	for d in ["apps", "apps/app_library", "lib"]:
-		try:
-			os.remove(d) # Sometimes FS corruption leads to files instead of folders
-		except OSError as e:
-			pass
-		try:
-			os.mkdir(d)
-		except OSError as e:
-			print(e)
+    while not success:
+        for d in ["apps", "apps/app_library", "lib"]:
+            try:
+                os.remove(d) # Sometimes FS corruption leads to files instead of folders
+            except OSError as e:
+                pass
+            try:
+                os.mkdir(d)
+            except OSError as e:
+                print(e)
 
-	try:
-		label.text("Downloading list of libraries")
-		master = get(URL + "/master.json").raise_for_status().json()
-		libs_to_update = []
-		for i, (lib, expected_hash) in enumerate(master["lib"].items()):
-			label.text("Downloading library: %s (%d/%d)" % (lib, i + 1, len(master["lib"])))
-			download(URL + "/master/lib/%s" % lib, "lib/%s" % lib, expected_hash)
+        try:
+            message.text = "Downloading list of libraries" + addendum
+            master = get(URL + "/master.json").raise_for_status().json()
+            libs_to_update = []
+            for i, (lib, expected_hash) in enumerate(master["lib"].items()):
+                message.text ="Downloading library: %s (%d/%d)%s" % (lib, i + 1, len(master["lib"]), addendum)
+                download(URL + "/master/lib/%s" % lib, "lib/%s" % lib, expected_hash)
 
-		label.text("Downloading app library")
-		download(URL + "/master/apps/app_library/main.py", "apps/app_library/main.py", master["apps"]["app_library"]["main.py"])
-		success = True
+            message.text = "Downloading app library" + addendum
+            download(URL + "/master/apps/app_library/main.py", "apps/app_library/main.py", master["apps"]["app_library"]["main.py"])
+            success = True
+
 	except Exception as e:
-		error_string = uio.StringIO()
-		sys.print_exception(e, error_string)
-		error_string = error_string.getvalue()
+            error_string = uio.StringIO()
+            sys.print_exception(e, error_string)
+            error_string = error_string.getvalue()
 
-		failure_counter += 1
-		print("Error:")
-		print(error_string)
+            failure_counter += 1
+            print("Error:")
+            print(error_string)
 
-		if failure_counter > 5:
-			label.text("Something went wrong for the 5th time, giving up :(\nError:\n%s" % error_string)
-			while True:
-				pyb.wfi()
+            if failure_counter > 5:
+                message.text = "Something went wrong for the 5th time, giving up :(\nError:\n%s" % error_string
+                while True:
+                    pyb.wfi()
 
-		label.text("Something went wrong, trying again...")
-		pyb.delay(1000)
+                    message.text = "Something went wrong, trying again..."
+                    pyb.delay(1000)
 
-os.sync()
-label.destroy()
-machine.reset()
+    os.sync()
+    machine.reset()

--- a/lib/dialogs.py
+++ b/lib/dialogs.py
@@ -116,7 +116,7 @@ def prompt_text(description, init_text = "", true_text="OK", false_text="Back", 
 		edit.destroy();
 	return default
 
-def prompt_option(options, index=0, text = "Please select one of the following:", title=None, select_text="OK", none_text=None):
+def prompt_option(options, index=0, text = "Please select one of the following:", title=None, select_text="A: OK", none_text=None):
 	"""Shows a dialog prompting for one of multiple options
 
 	If none_text is specified the user can use the B or Menu button to skip the selection

--- a/lib/dialogs.py
+++ b/lib/dialogs.py
@@ -116,7 +116,7 @@ def prompt_text(description, init_text = "", true_text="OK", false_text="Back", 
 		edit.destroy();
 	return default
 
-def prompt_option(options, index=0, text = "Please select one of the following:", title=None, select_text="A: OK", none_text=None):
+def prompt_option(options, index=0, text = "Please select one of the following:", title=None, select_text="OK", none_text=None):
 	"""Shows a dialog prompting for one of multiple options
 
 	If none_text is specified the user can use the B or Menu button to skip the selection

--- a/lib/http_client.py
+++ b/lib/http_client.py
@@ -6,6 +6,7 @@ import usocket
 import ujson
 import os
 import time
+import gc
 
 """Usage
 from http_client import *
@@ -216,9 +217,16 @@ def request(method, url, json=None, timeout=None, headers=None, urlencoded=None)
 				return response
 	finally:
 		if sock: sock.close()
+		gc.collect()
 
 def get(url, **kwargs):
-	return request('GET', url, **kwargs)
+	attempts = 0
+	while attempts < 3:
+		try:
+			return request('GET', url, **kwargs)
+		except OSError:
+			attempts += 1
+	raise
 
 def post(url, **kwargs):
 	return request('POST', url, **kwargs)

--- a/lib/ntp.py
+++ b/lib/ntp.py
@@ -46,7 +46,7 @@ def set_NTP_time():
 	t = get_NTP_time()
 	if t is None:
 		print("Could not set time from NTP")
-		return
+		return False
 
 	tz = 0
 	with database.Database() as db:
@@ -62,3 +62,5 @@ def set_NTP_time():
 	rtc = RTC()
 	rtc.init()
 	rtc.datetime(tm)
+
+	return True

--- a/lib/run_app.py
+++ b/lib/run_app.py
@@ -1,6 +1,5 @@
 
 def reset_and_run(path):
-	import stm
 	import pyb
 #	if stm.mem8[0x40002850] == 0:   # this battery backed RAM section is set to 0 when the name screen runs
 	with open('main.json', 'w') as f:
@@ -9,7 +8,10 @@ def reset_and_run(path):
 	pyb.hard_reset()
 
 def run_app(path):
-#	buttons.enable_menu_reset()
+	import buttons
+	buttons.init()
+	if not buttons.has_interrupt("BTN_MENU"):
+		buttons.enable_menu_reset()
 	try:
 		mod = __import__(path)
 		if "main" in dir(mod):
@@ -23,10 +25,9 @@ def run_app(path):
 		ugfx.clear()
 		ugfx.set_default_font(ugfx.FONT_SMALL)
 		w=ugfx.Container(0,0,ugfx.width(),ugfx.height())
-		l=ugfx.Label(0,0,ugfx.width(),ugfx.height(),s.getvalue(),parent=w)
+		ugfx.Label(0,0,ugfx.width(),ugfx.height(),s.getvalue(),parent=w)
 		w.show()
 		raise(e)
-	import onboard
 	import stm
 	stm.mem8[0x40002850] = 0x9C
 	import pyb


### PR DESCRIPTION
This is lots of little fixes that I really can't be bothered to split into individual PR's.

Important:
* New bootstrapper that allows wifi selection & uses new baked-in GUI, wifi, and HTTP libs - also committed into the micropython lib).
* Default to reset-and-run for all apps, but allow opt-out.
* Turns on menu reset for all apps.
* If an OSError is raised when writing files in the app library, auto-reset. This fixes the freezes during the second phase of bootstrapping.
* Wifi connect/selection moved to lib, meaning all apps that don't explicitly opt out (like home) will get a nice error dialog and choose wifi support.

Less important:
* Fixes button messaging ("A: OK" rather than just "OK")
* New default wifi app that does scanning, change install order, and default pinned apps.

Once this is merged we need to publish new versions of:
* App library
* Home

Related PR for the base firmware: https://github.com/emfcamp/micropython/pull/73